### PR TITLE
PoC 1: Adding a metric by reusing Open Problems code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "hnswlib>=0.8.0",
     "tomli>=2.2.1",
     "boto3-stubs-lite[s3]>=1.38.0",
+    "scib"
 ]
 
 [project.optional-dependencies]
@@ -74,12 +75,12 @@ docs = [
     "sphinx-autodoc-typehints",
     "sphinx-markdown-builder",
     "myst-parser",
-    "sphinxcontrib.mermaid", 
+    "sphinxcontrib.mermaid",
     "sphinx-rtd-theme",
     "sphinx-copybutton",
     "nbsphinx",
     "linkify-it-py",
-    
+
 ]
 
 [project.urls]

--- a/src/czbenchmarks/metrics/implementations.py
+++ b/src/czbenchmarks/metrics/implementations.py
@@ -7,7 +7,7 @@ from sklearn.metrics import (
     mean_squared_error,
 )
 from scipy.stats import pearsonr
-from .utils import compute_entropy_per_cell, mean_fold_metric, jaccard_score
+from .utils import compute_entropy_per_cell, mean_fold_metric, jaccard_score, pc_regression_score
 
 from .types import MetricRegistry, MetricType
 
@@ -60,6 +60,16 @@ metrics_registry.register(
     description=(
         "Batch-aware silhouette score that measures how well cells "
         "cluster across batches."
+    ),
+    tags={"integration"},
+)
+
+metrics_registry.register(
+    MetricType.PC_REGRESSION,
+    func=pc_regression_score,
+    required_args={"X", "adata_pre", "batch"},
+    description=(
+        "Compare variance explained by batch before and after integration"
     ),
     tags={"integration"},
 )

--- a/src/czbenchmarks/metrics/types.py
+++ b/src/czbenchmarks/metrics/types.py
@@ -20,6 +20,7 @@ class MetricType(Enum):
     # Integration metrics
     ENTROPY_PER_CELL = "entropy_per_cell"
     BATCH_SILHOUETTE = "batch_silhouette"
+    PC_REGRESSION = "pc_regression"
 
     # Cross-validation prediction metrics
     MEAN_FOLD_ACCURACY = "mean_fold_accuracy"

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -110,14 +110,14 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     from scib.metrics import pcr_comparison
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
-    log1p(adata_pre, inplace=True)
+    log1p(adata_pre)
     adata_pre.obs["BATCH"] = batch
     reduce_data(adata_pre, batch_key="BATCH")
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
     adata_post.obs["BATCH"] = batch
 
-    pcr_comparison(
+    return pcr_comparison(
         adata_pre,
         adata_post,
         covariate = "BATCH",

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -2,6 +2,7 @@ import collections
 import statistics
 from typing import Iterable, Union
 
+import anndata as ad
 import numpy as np
 import pandas as pd
 
@@ -90,6 +91,38 @@ def compute_entropy_per_cell(
         (-label_counts_per_cell_normed * _safelog(label_counts_per_cell_normed)).sum(1)
         / _safelog(np.array([len(unique_batch_labels)]))
     ).mean()
+
+
+def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Categorical, pd.Series, np.ndarray]) -> float:
+    """Compute PC regression score comparing variance explained by batch.
+
+    Args:
+        X: Cell embedding matrix of shape (n_cells, n_dimensions)
+        adata_pre: AnnData before integration of shape (n_cells, n_features)
+        batch: Series containing batch labels for each cell
+
+    Returns:
+        Difference in variance explained by batch before and after integration
+    """
+
+    from scanpy.preprocessing import normalize_total, log1p
+    from scib.preprocessing import reduce_data
+    from scib.metrics import pcr_comparison
+
+    normalize_total(adata_pre, target_sum=1e4, inplace=True)
+    log1p(adata_pre, inplace=True)
+    adata_pre.obs["BATCH"] = batch
+    reduce_data(adata_pre, batch_key="BATCH")
+
+    adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
+    adata_post.obs["BATCH"] = batch
+
+    pcr_comparison(
+        adata_pre,
+        adata_post,
+        covariate = "BATCH",
+        embed = "X_emb"
+    )
 
 
 def jaccard_score(y_true: set[str], y_pred: set[str]):

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -63,6 +63,7 @@ class BatchIntegrationTask(BaseTask):
             data: Dataset containing embedding and labels
         """
         self.embedding = data.get_output(model_type, DataType.EMBEDDING)
+        self.adata_pre = data.get_input(DataType.ANNDATA)
         self.batch_labels = data.get_input(DataType.METADATA)[self.batch_key]
         self.labels = data.get_input(DataType.METADATA)[self.label_key]
 
@@ -76,6 +77,7 @@ class BatchIntegrationTask(BaseTask):
 
         entropy_per_cell_metric = MetricType.ENTROPY_PER_CELL
         silhouette_batch_metric = MetricType.BATCH_SILHOUETTE
+        pc_regression_metric = MetricType.PC_REGRESSION
 
         return [
             MetricResult(
@@ -93,6 +95,15 @@ class BatchIntegrationTask(BaseTask):
                     silhouette_batch_metric,
                     X=self.embedding,
                     labels=self.labels,
+                    batch=self.batch_labels,
+                ),
+            ),
+            MetricResult(
+                metric_type=pc_regression_metric,
+                value=metrics_registry.compute(
+                    silhouette_batch_metric,
+                    X=self.embedding,
+                    adata_pre=self.adata_pre,
                     batch=self.batch_labels,
                 ),
             ),

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -101,7 +101,7 @@ class BatchIntegrationTask(BaseTask):
             MetricResult(
                 metric_type=pc_regression_metric,
                 value=metrics_registry.compute(
-                    silhouette_batch_metric,
+                    pc_regression_metric,
                     X=self.embedding,
                     adata_pre=self.adata_pre,
                     batch=self.batch_labels,


### PR DESCRIPTION
This proof of concept adds a new metric to the CZ Benchmarks integration task by re-using code from https://github.com/openproblems-bio/task_batch_integration:

- Add `PC_REGRESSION` to metric types
- Register the `PC_REGRESSION` metric
- Add a `pc_regression_score()` helper function to calculate the metric, borrowing code from https://github.com/openproblems-bio/task_batch_integration/blob/main/src/metrics/pcr/script.py
- Add the `scib` package as a dependency
- Add the `PC_REGRESSION` metric to the integration task