### PR TITLE
PoC 2: Adding a metric by using a built Viash component

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "hnswlib>=0.8.0",
     "tomli>=2.2.1",
     "boto3-stubs-lite[s3]>=1.38.0",
+    "scib"
 ]
 
 [project.optional-dependencies]
@@ -74,12 +75,12 @@ docs = [
     "sphinx-autodoc-typehints",
     "sphinx-markdown-builder",
     "myst-parser",
-    "sphinxcontrib.mermaid", 
+    "sphinxcontrib.mermaid",
     "sphinx-rtd-theme",
     "sphinx-copybutton",
     "nbsphinx",
     "linkify-it-py",
-    
+
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "hnswlib>=0.8.0",
     "tomli>=2.2.1",
-    "boto3-stubs-lite[s3]>=1.38.0",
-    "scib"
+    "boto3-stubs-lite[s3]>=1.38.0"
 ]
 
 [project.optional-dependencies]

--- a/src/czbenchmarks/metrics/implementations.py
+++ b/src/czbenchmarks/metrics/implementations.py
@@ -7,7 +7,7 @@ from sklearn.metrics import (
     mean_squared_error,
 )
 from scipy.stats import pearsonr
-from .utils import compute_entropy_per_cell, mean_fold_metric, jaccard_score
+from .utils import compute_entropy_per_cell, mean_fold_metric, jaccard_score, pc_regression_score
 
 from .types import MetricRegistry, MetricType
 
@@ -60,6 +60,16 @@ metrics_registry.register(
     description=(
         "Batch-aware silhouette score that measures how well cells "
         "cluster across batches."
+    ),
+    tags={"integration"},
+)
+
+metrics_registry.register(
+    MetricType.PC_REGRESSION,
+    func=pc_regression_score,
+    required_args={"X", "adata_pre", "batch"},
+    description=(
+        "Compare variance explained by batch before and after integration"
     ),
     tags={"integration"},
 )

--- a/src/czbenchmarks/metrics/types.py
+++ b/src/czbenchmarks/metrics/types.py
@@ -20,6 +20,7 @@ class MetricType(Enum):
     # Integration metrics
     ENTROPY_PER_CELL = "entropy_per_cell"
     BATCH_SILHOUETTE = "batch_silhouette"
+    PC_REGRESSION = "pc_regression"
 
     # Cross-validation prediction metrics
     MEAN_FOLD_ACCURACY = "mean_fold_accuracy"

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -110,14 +110,14 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     from scib.metrics import pcr_comparison
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
-    log1p(adata_pre, inplace=True)
+    log1p(adata_pre)
     adata_pre.obs["BATCH"] = batch
     reduce_data(adata_pre, batch_key="BATCH")
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
     adata_post.obs["BATCH"] = batch
 
-    pcr_comparison(
+    return pcr_comparison(
         adata_pre,
         adata_post,
         covariate = "BATCH",

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -2,6 +2,7 @@ import collections
 import statistics
 from typing import Iterable, Union
 
+import anndata as ad
 import numpy as np
 import pandas as pd
 
@@ -90,6 +91,38 @@ def compute_entropy_per_cell(
         (-label_counts_per_cell_normed * _safelog(label_counts_per_cell_normed)).sum(1)
         / _safelog(np.array([len(unique_batch_labels)]))
     ).mean()
+
+
+def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Categorical, pd.Series, np.ndarray]) -> float:
+    """Compute PC regression score comparing variance explained by batch.
+
+    Args:
+        X: Cell embedding matrix of shape (n_cells, n_dimensions)
+        adata_pre: AnnData before integration of shape (n_cells, n_features)
+        batch: Series containing batch labels for each cell
+
+    Returns:
+        Difference in variance explained by batch before and after integration
+    """
+
+    from scanpy.preprocessing import normalize_total, log1p
+    from scib.preprocessing import reduce_data
+    from scib.metrics import pcr_comparison
+
+    normalize_total(adata_pre, target_sum=1e4, inplace=True)
+    log1p(adata_pre, inplace=True)
+    adata_pre.obs["BATCH"] = batch
+    reduce_data(adata_pre, batch_key="BATCH")
+
+    adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
+    adata_post.obs["BATCH"] = batch
+
+    pcr_comparison(
+        adata_pre,
+        adata_post,
+        covariate = "BATCH",
+        embed = "X_emb"
+    )
 
 
 def jaccard_score(y_true: set[str], y_pred: set[str]):

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -129,9 +129,9 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     # This assumes everything is in the correct location
     cmd = [
         "./.viash_build/pcr/pcr",
-        f"--input_integrated {h5ad_post}",
-        f"--input_solution {h5ad_pre}",
-        f"--output {h5ad_out}"
+        "--input_integrated", f"{h5ad_post}",
+        "--input_solution", f"{h5ad_pre}",
+        "--output", f"{h5ad_out}"
     ]
     subprocess.run(cmd, check=True)
 

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -125,6 +125,9 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     h5ad_post = f"{temp_dir}/adata_post.h5ad"
     h5ad_out = f"{temp_dir}/pcr_output.h5ad"
 
+    adata_pre.write_h5ad(h5ad_pre)
+    adata_post.write_h5ad(h5ad_post)
+
     # Call the Viash component
     # This assumes everything is in the correct location
     cmd = [

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -107,7 +107,10 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
 
     from scanpy.preprocessing import normalize_total, log1p
     from scib.preprocessing import reduce_data
-    from scib.metrics import pcr_comparison
+
+    import subprocess
+    import tempfile
+    import shutil
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
     log1p(adata_pre)
@@ -117,12 +120,28 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
     adata_post.obs["BATCH"] = batch
 
-    return pcr_comparison(
-        adata_pre,
-        adata_post,
-        covariate = "BATCH",
-        embed = "X_emb"
-    )
+    temp_dir = tempfile.mkdtemp()
+    h5ad_pre = f"{temp_dir}/adata_pre.h5ad"
+    h5ad_post = f"{temp_dir}/adata_post.h5ad"
+    h5ad_out = f"{temp_dir}/pcr_output.h5ad"
+
+    # Call the Viash component
+    # This assumes everything is in the correct location
+    cmd = [
+        "./.viash_build/pcr/pcr",
+        f"--input_integrated {h5ad_post}",
+        f"--input_solution {h5ad_pre}",
+        f"--output {h5ad_out}"
+    ]
+    subprocess.run(cmd, check=True)
+
+    # Load the output h5ad file
+    adata_out = ad.read_h5ad(h5ad_out)
+
+    # Clean up temporary files
+    shutil.rmtree(temp_dir)
+
+    return adata_out.uns["metric_values"][0]
 
 
 def jaccard_score(y_true: set[str], y_pred: set[str]):

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -114,11 +114,15 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
     log1p(adata_pre)
-    adata_pre.layers["normalized"] = adata_pre.X.copy()
     adata_pre.obs["batch"] = batch
     reduce_data(adata_pre, batch_key="batch")
+    adata_pre.layers["normalized"] = adata_pre.X.copy()
+    adata_pre.var["batch_hvg"] = adata_pre.var["highly_variable"]
+    adata_pre.uns["dataset_id"] = "dummy"
+    adata_pre.uns["normalization_id"] = "log1p"
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
+    adata_post.uns["method_id"] = "dummy"
 
     temp_dir = tempfile.mkdtemp()
     h5ad_pre = f"{temp_dir}/adata_pre.h5ad"

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -114,11 +114,11 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
     log1p(adata_pre)
-    adata_pre.obs["BATCH"] = batch
-    reduce_data(adata_pre, batch_key="BATCH")
+    adata_pre.layers["normalized"] = adata_pre.X.copy()
+    adata_pre.obs["batch"] = batch
+    reduce_data(adata_pre, batch_key="batch")
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
-    adata_post.obs["BATCH"] = batch
 
     temp_dir = tempfile.mkdtemp()
     h5ad_pre = f"{temp_dir}/adata_pre.h5ad"

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -63,6 +63,7 @@ class BatchIntegrationTask(BaseTask):
             data: Dataset containing embedding and labels
         """
         self.embedding = data.get_output(model_type, DataType.EMBEDDING)
+        self.adata_pre = data.get_input(DataType.ANNDATA)
         self.batch_labels = data.get_input(DataType.METADATA)[self.batch_key]
         self.labels = data.get_input(DataType.METADATA)[self.label_key]
 
@@ -76,6 +77,7 @@ class BatchIntegrationTask(BaseTask):
 
         entropy_per_cell_metric = MetricType.ENTROPY_PER_CELL
         silhouette_batch_metric = MetricType.BATCH_SILHOUETTE
+        pc_regression_metric = MetricType.PC_REGRESSION
 
         return [
             MetricResult(
@@ -93,6 +95,15 @@ class BatchIntegrationTask(BaseTask):
                     silhouette_batch_metric,
                     X=self.embedding,
                     labels=self.labels,
+                    batch=self.batch_labels,
+                ),
+            ),
+            MetricResult(
+                metric_type=pc_regression_metric,
+                value=metrics_registry.compute(
+                    silhouette_batch_metric,
+                    X=self.embedding,
+                    adata_pre=self.adata_pre,
                     batch=self.batch_labels,
                 ),
             ),

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -101,7 +101,7 @@ class BatchIntegrationTask(BaseTask):
             MetricResult(
                 metric_type=pc_regression_metric,
                 value=metrics_registry.compute(
-                    silhouette_batch_metric,
+                    pc_regression_metric,
                     X=self.embedding,
                     adata_pre=self.adata_pre,
                     batch=self.batch_labels,


### PR DESCRIPTION
This proof of concept adds a new metric to the CZ Benchmarks integration task by using a pre-built Viash component from [openproblems-bio/task_batch_integration](https://github.com/openproblems-bio/task_batch_integration) (builds on #1):

- Modify the `pc_regression_score()` helper function from #1:
  - Create input `AnnData` objects in the format defined by the Open Problems task API
  - Write temporary H5AD input files
  - Call the Viash component via the command line
  - Read the output H5AD file
  - Clean up temporary files
  - Return the metric score