### PR TITLE
PoC 3: Adding a metric by pulling and building a Viash component

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "hnswlib>=0.8.0",
     "tomli>=2.2.1",
     "boto3-stubs-lite[s3]>=1.38.0",
+    "scib"
 ]
 
 [project.optional-dependencies]
@@ -74,12 +75,12 @@ docs = [
     "sphinx-autodoc-typehints",
     "sphinx-markdown-builder",
     "myst-parser",
-    "sphinxcontrib.mermaid", 
+    "sphinxcontrib.mermaid",
     "sphinx-rtd-theme",
     "sphinx-copybutton",
     "nbsphinx",
     "linkify-it-py",
-    
+
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "hnswlib>=0.8.0",
     "tomli>=2.2.1",
-    "boto3-stubs-lite[s3]>=1.38.0",
-    "scib"
+    "boto3-stubs-lite[s3]>=1.38.0"
 ]
 
 [project.optional-dependencies]

--- a/src/czbenchmarks/metrics/implementations.py
+++ b/src/czbenchmarks/metrics/implementations.py
@@ -7,7 +7,7 @@ from sklearn.metrics import (
     mean_squared_error,
 )
 from scipy.stats import pearsonr
-from .utils import compute_entropy_per_cell, mean_fold_metric, jaccard_score
+from .utils import compute_entropy_per_cell, mean_fold_metric, jaccard_score, pc_regression_score
 
 from .types import MetricRegistry, MetricType
 
@@ -60,6 +60,16 @@ metrics_registry.register(
     description=(
         "Batch-aware silhouette score that measures how well cells "
         "cluster across batches."
+    ),
+    tags={"integration"},
+)
+
+metrics_registry.register(
+    MetricType.PC_REGRESSION,
+    func=pc_regression_score,
+    required_args={"X", "adata_pre", "batch"},
+    description=(
+        "Compare variance explained by batch before and after integration"
     ),
     tags={"integration"},
 )

--- a/src/czbenchmarks/metrics/types.py
+++ b/src/czbenchmarks/metrics/types.py
@@ -20,6 +20,7 @@ class MetricType(Enum):
     # Integration metrics
     ENTROPY_PER_CELL = "entropy_per_cell"
     BATCH_SILHOUETTE = "batch_silhouette"
+    PC_REGRESSION = "pc_regression"
 
     # Cross-validation prediction metrics
     MEAN_FOLD_ACCURACY = "mean_fold_accuracy"

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -110,14 +110,14 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     from scib.metrics import pcr_comparison
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
-    log1p(adata_pre, inplace=True)
+    log1p(adata_pre)
     adata_pre.obs["BATCH"] = batch
     reduce_data(adata_pre, batch_key="BATCH")
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
     adata_post.obs["BATCH"] = batch
 
-    pcr_comparison(
+    return pcr_comparison(
         adata_pre,
         adata_post,
         covariate = "BATCH",

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -2,6 +2,7 @@ import collections
 import statistics
 from typing import Iterable, Union
 
+import anndata as ad
 import numpy as np
 import pandas as pd
 
@@ -90,6 +91,38 @@ def compute_entropy_per_cell(
         (-label_counts_per_cell_normed * _safelog(label_counts_per_cell_normed)).sum(1)
         / _safelog(np.array([len(unique_batch_labels)]))
     ).mean()
+
+
+def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Categorical, pd.Series, np.ndarray]) -> float:
+    """Compute PC regression score comparing variance explained by batch.
+
+    Args:
+        X: Cell embedding matrix of shape (n_cells, n_dimensions)
+        adata_pre: AnnData before integration of shape (n_cells, n_features)
+        batch: Series containing batch labels for each cell
+
+    Returns:
+        Difference in variance explained by batch before and after integration
+    """
+
+    from scanpy.preprocessing import normalize_total, log1p
+    from scib.preprocessing import reduce_data
+    from scib.metrics import pcr_comparison
+
+    normalize_total(adata_pre, target_sum=1e4, inplace=True)
+    log1p(adata_pre, inplace=True)
+    adata_pre.obs["BATCH"] = batch
+    reduce_data(adata_pre, batch_key="BATCH")
+
+    adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
+    adata_post.obs["BATCH"] = batch
+
+    pcr_comparison(
+        adata_pre,
+        adata_post,
+        covariate = "BATCH",
+        embed = "X_emb"
+    )
 
 
 def jaccard_score(y_true: set[str], y_pred: set[str]):

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from ..tasks.constants import RANDOM_SEED
 from .types import AggregatedMetricResult, MetricResult
+from ..openproblems.openproblems import get_metric_executable
 
 
 def _safelog(a: np.ndarray) -> np.ndarray:
@@ -133,9 +134,9 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     adata_post.write_h5ad(h5ad_post)
 
     # Call the Viash component
-    # This assumes everything is in the correct location
+    metric_executable = get_metric_executable("task_batch_integration", "pcr")
     cmd = [
-        "./.viash_build/pcr/pcr",
+        metric_executable,
         "--input_integrated", f"{h5ad_post}",
         "--input_solution", f"{h5ad_pre}",
         "--output", f"{h5ad_out}"

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -129,9 +129,9 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     # This assumes everything is in the correct location
     cmd = [
         "./.viash_build/pcr/pcr",
-        f"--input_integrated {h5ad_post}",
-        f"--input_solution {h5ad_pre}",
-        f"--output {h5ad_out}"
+        "--input_integrated", f"{h5ad_post}",
+        "--input_solution", f"{h5ad_pre}",
+        "--output", f"{h5ad_out}"
     ]
     subprocess.run(cmd, check=True)
 

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -125,6 +125,9 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     h5ad_post = f"{temp_dir}/adata_post.h5ad"
     h5ad_out = f"{temp_dir}/pcr_output.h5ad"
 
+    adata_pre.write_h5ad(h5ad_pre)
+    adata_post.write_h5ad(h5ad_post)
+
     # Call the Viash component
     # This assumes everything is in the correct location
     cmd = [

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -107,7 +107,10 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
 
     from scanpy.preprocessing import normalize_total, log1p
     from scib.preprocessing import reduce_data
-    from scib.metrics import pcr_comparison
+
+    import subprocess
+    import tempfile
+    import shutil
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
     log1p(adata_pre)
@@ -117,12 +120,28 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
     adata_post.obs["BATCH"] = batch
 
-    return pcr_comparison(
-        adata_pre,
-        adata_post,
-        covariate = "BATCH",
-        embed = "X_emb"
-    )
+    temp_dir = tempfile.mkdtemp()
+    h5ad_pre = f"{temp_dir}/adata_pre.h5ad"
+    h5ad_post = f"{temp_dir}/adata_post.h5ad"
+    h5ad_out = f"{temp_dir}/pcr_output.h5ad"
+
+    # Call the Viash component
+    # This assumes everything is in the correct location
+    cmd = [
+        "./.viash_build/pcr/pcr",
+        f"--input_integrated {h5ad_post}",
+        f"--input_solution {h5ad_pre}",
+        f"--output {h5ad_out}"
+    ]
+    subprocess.run(cmd, check=True)
+
+    # Load the output h5ad file
+    adata_out = ad.read_h5ad(h5ad_out)
+
+    # Clean up temporary files
+    shutil.rmtree(temp_dir)
+
+    return adata_out.uns["metric_values"][0]
 
 
 def jaccard_score(y_true: set[str], y_pred: set[str]):

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -114,11 +114,15 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
     log1p(adata_pre)
-    adata_pre.layers["normalized"] = adata_pre.X.copy()
     adata_pre.obs["batch"] = batch
     reduce_data(adata_pre, batch_key="batch")
+    adata_pre.layers["normalized"] = adata_pre.X.copy()
+    adata_pre.var["batch_hvg"] = adata_pre.var["highly_variable"]
+    adata_pre.uns["dataset_id"] = "dummy"
+    adata_pre.uns["normalization_id"] = "log1p"
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
+    adata_post.uns["method_id"] = "dummy"
 
     temp_dir = tempfile.mkdtemp()
     h5ad_pre = f"{temp_dir}/adata_pre.h5ad"

--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -114,11 +114,11 @@ def pc_regression_score(X: np.ndarray, adata_pre: ad.AnnData, batch: Union[pd.Ca
 
     normalize_total(adata_pre, target_sum=1e4, inplace=True)
     log1p(adata_pre)
-    adata_pre.obs["BATCH"] = batch
-    reduce_data(adata_pre, batch_key="BATCH")
+    adata_pre.layers["normalized"] = adata_pre.X.copy()
+    adata_pre.obs["batch"] = batch
+    reduce_data(adata_pre, batch_key="batch")
 
     adata_post = ad.AnnData(shape = X.shape, obsm={"X_emb": X})
-    adata_post.obs["BATCH"] = batch
 
     temp_dir = tempfile.mkdtemp()
     h5ad_pre = f"{temp_dir}/adata_pre.h5ad"

--- a/src/czbenchmarks/openproblems/__init__.py
+++ b/src/czbenchmarks/openproblems/__init__.py
@@ -1,0 +1,7 @@
+from .openproblems import get_metric_executable, clone_task_repo, build_viash_component
+
+__all__ = [
+    "get_metric_executable",
+    "clone_task_repo",
+    "build_viash_component",
+]

--- a/src/czbenchmarks/openproblems/openproblems.py
+++ b/src/czbenchmarks/openproblems/openproblems.py
@@ -51,7 +51,7 @@ def build_viash_component(repo_path: str, component_path: str) -> str:
         component_path: Path to the component within the repository
 
     Returns:
-        Path to the built Viash component executable
+        Absolute path to the built Viash component executable
     """
 
     config_path = os.path.join(component_path, "config.vsh.yaml")
@@ -64,7 +64,7 @@ def build_viash_component(repo_path: str, component_path: str) -> str:
     executable_path = os.path.join(repo_path, target_path, component_name)
 
     if os.path.exists(executable_path):
-        return executable_path
+        return os.path.abspath(executable_path)
 
     os.chdir(repo_path)
     subprocess.run(
@@ -79,4 +79,4 @@ def build_viash_component(repo_path: str, component_path: str) -> str:
         check=True
     )
 
-    return executable_path
+    return os.path.abspath(executable_path)

--- a/src/czbenchmarks/openproblems/openproblems.py
+++ b/src/czbenchmarks/openproblems/openproblems.py
@@ -1,0 +1,82 @@
+import os
+import subprocess
+import yaml
+
+def get_metric_executable(task: str, metric: str) -> str:
+    """Get the path to the built Viash executable for a given Open Problems task
+    and metric.
+
+    Args:
+        task: Name of the task (e.g., "task_batch_integration")
+        metric: Name of the metric (e.g., "pcr", "aws_batch")
+
+    Returns:
+        Path to the Viash component executable
+    """
+
+    task_repo = clone_task_repo(task)
+
+    metric_path = f"src/metrics/{metric}"
+    metric_executable = build_viash_component(task_repo, metric_path)
+
+    return metric_executable
+
+
+def clone_task_repo(task: str) -> str:
+    """Clone an Open Problems task repository.
+
+    Args:
+        task: Name of the task to clone
+
+    Returns:
+        Path to the cloned repository
+    """
+
+    repo_url = f"https://github.com/openproblems-bio/{task}.git"
+    repo_path = f"./.openproblems/{task}"
+
+    if not os.path.exists(repo_path):
+        subprocess.run(["git", "clone", repo_url, repo_path], check=True)
+    else:
+        subprocess.run(["git", "-C", repo_path, "pull"], check=True)
+
+    return repo_path
+
+
+def build_viash_component(repo_path: str, component_path: str) -> str:
+    """Build a Viash component from the given repository and component path.
+
+    Args:
+        repo_path: Path to the cloned repository
+        component_path: Path to the component within the repository
+
+    Returns:
+        Path to the built Viash component executable
+    """
+
+    config_path = os.path.join(component_path, "config.vsh.yaml")
+
+    with open(os.path.join(repo_path, config_path), 'r') as f:
+        config = yaml.safe_load(f)
+
+    component_name = config.get("name")
+    target_path = os.path.join("target", component_path)
+    executable_path = os.path.join(repo_path, target_path, component_name)
+
+    if os.path.exists(executable_path):
+        return executable_path
+
+    os.chdir(repo_path)
+    subprocess.run(
+        [
+            "viash", "build",
+            "--engine", "docker",
+            "--runner", "executable",
+            "--setup", "ifneedbepullelsecachedbuild",
+            "--output", target_path,
+            config_path
+        ],
+        check=True
+    )
+
+    return executable_path

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -63,6 +63,7 @@ class BatchIntegrationTask(BaseTask):
             data: Dataset containing embedding and labels
         """
         self.embedding = data.get_output(model_type, DataType.EMBEDDING)
+        self.adata_pre = data.get_input(DataType.ANNDATA)
         self.batch_labels = data.get_input(DataType.METADATA)[self.batch_key]
         self.labels = data.get_input(DataType.METADATA)[self.label_key]
 
@@ -76,6 +77,7 @@ class BatchIntegrationTask(BaseTask):
 
         entropy_per_cell_metric = MetricType.ENTROPY_PER_CELL
         silhouette_batch_metric = MetricType.BATCH_SILHOUETTE
+        pc_regression_metric = MetricType.PC_REGRESSION
 
         return [
             MetricResult(
@@ -93,6 +95,15 @@ class BatchIntegrationTask(BaseTask):
                     silhouette_batch_metric,
                     X=self.embedding,
                     labels=self.labels,
+                    batch=self.batch_labels,
+                ),
+            ),
+            MetricResult(
+                metric_type=pc_regression_metric,
+                value=metrics_registry.compute(
+                    silhouette_batch_metric,
+                    X=self.embedding,
+                    adata_pre=self.adata_pre,
                     batch=self.batch_labels,
                 ),
             ),

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -101,7 +101,7 @@ class BatchIntegrationTask(BaseTask):
             MetricResult(
                 metric_type=pc_regression_metric,
                 value=metrics_registry.compute(
-                    silhouette_batch_metric,
+                    pc_regression_metric,
                     X=self.embedding,
                     adata_pre=self.adata_pre,
                     batch=self.batch_labels,


### PR DESCRIPTION
This proof of concept adds a new metric to the CZ Benchmarks integration task by pulling and building a Viash component from https://github.com/openproblems-bio/task_batch_integration (builds on #2):

- Add an `openproblems` submodule
- Add a `get_metric_executable()` helper function that returns a path to a built Viash executable
- Add a `clone_task_repo()` helper function that clones (or updates) an Open Problems task repository to a cache directory
- Add a `build_viash_component()` helper function that builds a Viash component executable
- Modify the `pc_regression_score()` helper function from #2 to use `get_metric_executable()`